### PR TITLE
fix: 지갑(Wallet)에서 거래 내역이 표시되지 않는 문제

### DIFF
--- a/src/common/api/steem.ts
+++ b/src/common/api/steem.ts
@@ -298,7 +298,7 @@ export const getDynamicGlobalProperties = (): Promise<DynamicGlobalProperties> =
     };
   });
 
-export const getAccountHistory = (username: string, start: number = -1, limit: number = 100): Promise<any> => {
+export const getAccountHistory = (username: string, start: number = -1, limit: number = 20): Promise<any> => {
   // return axios({
   //   url: `https://sds.steemworld.org/account_history_api/getHistoryByOpTypesTime/${username}/${filters}/1420070400-32503680000/${limit}/${start}`,
   //   method: "GET",

--- a/src/common/components/wallet-steem-engine/index.tsx
+++ b/src/common/components/wallet-steem-engine/index.tsx
@@ -509,7 +509,7 @@ export default (p: Props) => {
     updateWalletValues: p.updateWalletValues,
     fetchPoints: p.fetchPoints,
     fetchTransactions: p.fetchTransactions,
-    steemengine: true,
+    steemengine: false,
   };
 
   return <WalletSteemEngine {...props} />;

--- a/src/common/store/transactions/index.ts
+++ b/src/common/store/transactions/index.ts
@@ -56,7 +56,7 @@ export default (state: Transactions = initialState, action: Actions): Transactio
 
 /* Actions */
 export const fetchTransactions =
-  (username: string, steemengine: boolean, group: OperationGroup | "" = "", start: number = -1, limit: number = 100) =>
+  (username: string, steemengine: boolean, group: OperationGroup | "" = "", start: number = -1, limit: number = 20) =>
   async (dispatch: Dispatch) => {
     dispatch(fetchAct(group));
 


### PR DESCRIPTION
## 증상
Wallet에서 로딩바만 표시되고 거래 내역은 표시되지 않음.
<img width="1113" src="https://github.com/realmankwon/upvu_web/assets/3969643/f72c2a8f-bb20-46c6-a7d2-f996e8dbdf4b">

## 원인
`condenser_api.get_account_history` API에서 다음과 같은 에러가 발생.
```
{"error":{"code":-32801,"message":"condenser_api.get_account_history upper limit is 20","id":1},"jsonrpc":"2.0"}
```
이 문제는 4개월전 Steem 공식 API에 새로운 제한 규칙이 추가된 것과 관련이 있음. 
참조: [https://steemit.com/steem/@ety001/notice-steem-official-api-has-added-some-new-limit-rules](https://steemit.com/steem/@ety001/notice-steem-official-api-has-added-some-new-limit-rules)

## 해결
`get_account_history` API 호출 함수에서 기본 limit를 20으로 변경함.
